### PR TITLE
Fix missing |= 8 for byte 2 in encode 8

### DIFF
--- a/ggnesconv.c
+++ b/ggnesconv.c
@@ -30,6 +30,7 @@ void hex_to_nes(unsigned int address, unsigned int data, unsigned int compare)
 	n[1] |= 7 & ( data >> 4 ); //
 
 	n[2] |= 7 & (address >> 4);
+	n[2] |= 8;
 
 	n[3] |= 7 & (address >> 12);
 	n[3] |= 8 & address;


### PR DESCRIPTION
6 and 8 letter codes are encoded identically for the first four letters.
Without this missing |= 8, 8 letter codes have a mis-encoded third letter.

```
zachary-mark@home:~/gamegenie_nes_converter (master)$ ./ggnesconv AAEAULPA
address data compare : 0x8b03 0x00 0x01
zachary-mark@home:~/gamegenie_nes_converter (master)$ ./ggnesconv 0x8b03 0x00 0x01
AAAAULPA
```